### PR TITLE
[Navigation Entities] Add navigation-menu-item and navigation-item db models

### DIFF
--- a/api/navigation-item/config/routes.json
+++ b/api/navigation-item/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/navigation-items",
+      "handler": "navigation-item.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/navigation-items/count",
+      "handler": "navigation-item.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/navigation-items/:id",
+      "handler": "navigation-item.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/navigation-items",
+      "handler": "navigation-item.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/navigation-items/:id",
+      "handler": "navigation-item.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/navigation-items/:id",
+      "handler": "navigation-item.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/api/navigation-item/controllers/navigation-item.js
+++ b/api/navigation-item/controllers/navigation-item.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/api/navigation-item/models/navigation-item.js
+++ b/api/navigation-item/models/navigation-item.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/api/navigation-item/models/navigation-item.settings.json
+++ b/api/navigation-item/models/navigation-item.settings.json
@@ -1,0 +1,33 @@
+{
+  "kind": "collectionType",
+  "collectionName": "navigation_items",
+  "info": {
+    "name": "Navigation Item",
+    "description": ""
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true,
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "url": {
+      "type": "string",
+      "required": true
+    },
+    "sort_order": {
+      "type": "integer",
+      "required": true,
+      "default": 1
+    },
+    "navigation_menu_item": {
+      "model": "navigation-menu-item",
+      "via": "navigation_items"
+    }
+  }
+}

--- a/api/navigation-item/services/navigation-item.js
+++ b/api/navigation-item/services/navigation-item.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/api/navigation-menu-item/config/routes.json
+++ b/api/navigation-menu-item/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/navigation-menu-items",
+      "handler": "navigation-menu-item.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/navigation-menu-items/count",
+      "handler": "navigation-menu-item.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/navigation-menu-items/:id",
+      "handler": "navigation-menu-item.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/navigation-menu-items",
+      "handler": "navigation-menu-item.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/navigation-menu-items/:id",
+      "handler": "navigation-menu-item.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/navigation-menu-items/:id",
+      "handler": "navigation-menu-item.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/api/navigation-menu-item/controllers/navigation-menu-item.js
+++ b/api/navigation-menu-item/controllers/navigation-menu-item.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/api/navigation-menu-item/models/navigation-menu-item.js
+++ b/api/navigation-menu-item/models/navigation-menu-item.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/api/navigation-menu-item/models/navigation-menu-item.settings.json
+++ b/api/navigation-menu-item/models/navigation-menu-item.settings.json
@@ -1,0 +1,29 @@
+{
+  "kind": "collectionType",
+  "collectionName": "navigation_menu_items",
+  "info": {
+    "name": "Navigation Menu Item",
+    "description": ""
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true,
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "sort_order": {
+      "type": "integer",
+      "default": 1,
+      "required": true
+    },
+    "navigation_items": {
+      "via": "navigation_menu_item",
+      "collection": "navigation-item"
+    }
+  }
+}

--- a/api/navigation-menu-item/services/navigation-menu-item.js
+++ b/api/navigation-menu-item/services/navigation-menu-item.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/extensions/users-permissions/config/jwt.js
+++ b/extensions/users-permissions/config/jwt.js
@@ -1,0 +1,3 @@
+module.exports = {
+  jwtSecret: process.env.JWT_SECRET || 'be2e4bd5-3e8b-4297-b0bc-e6be51b53dd3'
+};


### PR DESCRIPTION
The structure of models is as following:

Navigation Bar is made up of many `NavigationMenuItem` and each `NavigationMenuItem` has many `NavigationItem`
  

